### PR TITLE
Change to non-root user prior to ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 8000
 VOLUME ["/var/log/icecast"]
+USER icecast
 ENTRYPOINT ["/entrypoint.sh"]
 CMD icecast -c /etc/icecast.xml


### PR DESCRIPTION
This also ensures that the icecast process is started as a non-root user. However, a WARNING is displayed because the default icecast config will automatically try to switch to the icecast user but fail because icecast is not running as root.